### PR TITLE
Limit memory, kernel memory, cpu and nproc

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 
 const stripAnsi = require("strip-ansi");
 const associations = require("./associations");
+const limits = require('./limits')
 
 const embed = (name, content) => {
   return {
@@ -44,7 +45,8 @@ module.exports.create = async (channel, db, associationKey) => {
     {
       Image: image,
       Tty: true,
-      Cmd: [ "/bin/sh" ]
+      Cmd: [ "/bin/sh" ],
+      ...limits
     },
     async (error, container) => {
       if (error) {

--- a/limits.js
+++ b/limits.js
@@ -1,0 +1,22 @@
+const kb = 1024
+const mb = kb * 1024
+
+module.exports = {
+  // prevent container from spawning more then 64 processes (mitigate fork bomb)
+  Ulimits: [
+    {Name: 'nproc', Soft: 64, Hard: 64}
+  ],
+
+  // cap cpu per container at 10% of one core
+  NanoCpus: 1e8,
+
+  // limit memory so they can't consume it all
+  Memory: mb * 64,
+
+  // so docker warned that this might be bad, but limits can't ever be bad!
+  // I'm sure the kernel will be fine with running out of memory in the container,
+  // there are zero things that could go wrong
+  //
+  // ZERO
+  KernelMemory: mb * 64,
+}


### PR DESCRIPTION
Prevent the chad `:() { :|:& } ;:` from taking us down 